### PR TITLE
Bootstrap Flask + SQLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Imposta SECRET_KEY per sessioni Flask (opzionale).
+# SECRET_KEY=change-me
+
+# Imposta DATABASE_URL per usare un database diverso da SQLite locale.
+# DATABASE_URL=sqlite:///instance/app.db
+
+# Abilita logging SQL verbose impostando a 1.
+# SQLALCHEMY_ECHO=0

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # hello-codex
-test per codex agent
+
+Bootstrap project Flask + SQLite per demo Codex.
+
+## Requisiti
+
+- Python 3.12+
+- [Poetry](https://python-poetry.org/) **non necessario**: il progetto usa `pip` classico via `pyproject.toml`
+
+## Setup locale
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # oppure .venv\\Scripts\\activate su Windows
+pip install -U pip
+pip install -e .[dev]
+```
+
+Copia `.env.example` in `.env` se devi personalizzare la configurazione. In mancanza delle variabili d'ambiente il progetto usa un database SQLite in `instance/app.db` e una secret key di sviluppo.
+
+## Avvio server di sviluppo
+
+```bash
+flask --app app_flask run --debug
+```
+
+Al primo avvio l'applicazione crea automaticamente le tabelle. Puoi anche forzare la creazione/ripristino via CLI:
+
+```bash
+flask --app app_flask init-db
+```
+
+Rotte disponibili:
+
+- `GET /` → payload JSON di benvenuto
+- `GET /projects` → elenco dei progetti presenti nel database
+
+## Test
+
+```bash
+pytest
+```
+
+## Struttura progetto
+
+- `app_flask/` → applicazione Flask, modelli e blueprint
+- `tests/` → test Pytest
+- `instance/` → directory creata runtime contenente il database SQLite

--- a/app_flask/__init__.py
+++ b/app_flask/__init__.py
@@ -1,0 +1,48 @@
+"""Application factory for the hello-codex Flask project."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import click
+from flask import Flask
+
+from .config import Config
+from .extensions import db
+from .routes import bp as main_blueprint
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INSTANCE_PATH = BASE_DIR / "instance"
+
+
+def create_app(config_object: type[Config] | Config | None = None) -> Flask:
+    """Create and configure a :class:`flask.Flask` application instance."""
+    app = Flask(__name__, instance_path=str(INSTANCE_PATH))
+    app.config.from_object(config_object or Config)
+
+    INSTANCE_PATH.mkdir(parents=True, exist_ok=True)
+
+    db.init_app(app)
+
+    register_blueprints(app)
+    register_cli(app)
+
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+
+def register_blueprints(app: Flask) -> None:
+    """Attach application blueprints."""
+    app.register_blueprint(main_blueprint)
+
+
+def register_cli(app: Flask) -> None:
+    """Register custom Flask CLI commands."""
+
+    @app.cli.command("init-db")
+    def init_db_command() -> None:
+        """Initialise the SQLite database with the configured models."""
+        with app.app_context():
+            db.create_all()
+        click.secho("Database initialised.", fg="green")

--- a/app_flask/config.py
+++ b/app_flask/config.py
@@ -1,0 +1,22 @@
+"""Configuration objects for the Flask application."""
+
+from __future__ import annotations
+
+from os import getenv
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+DEFAULT_DB_PATH = BASE_DIR / "instance" / "app.db"
+
+
+def _default_database_uri() -> str:
+    return f"sqlite:///{DEFAULT_DB_PATH}".replace("\\", "/")
+
+
+class Config:
+    """Base configuration suitable for local development."""
+
+    SECRET_KEY = getenv("SECRET_KEY", "dev-secret-key")
+    SQLALCHEMY_DATABASE_URI = getenv("DATABASE_URL", _default_database_uri())
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SQLALCHEMY_ECHO = getenv("SQLALCHEMY_ECHO", "0") == "1"

--- a/app_flask/extensions.py
+++ b/app_flask/extensions.py
@@ -1,0 +1,8 @@
+"""Extension instances used across the Flask project."""
+
+from __future__ import annotations
+
+from flask_sqlalchemy import SQLAlchemy
+
+
+db: SQLAlchemy = SQLAlchemy()

--- a/app_flask/models.py
+++ b/app_flask/models.py
@@ -1,0 +1,23 @@
+"""Database models for the hello-codex application."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .extensions import db
+
+
+class Project(db.Model):
+    """Simple project entity used for bootstrapping the database schema."""
+
+    __tablename__ = "projects"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=lambda: datetime.now(UTC), nullable=False)
+
+    def __repr__(self) -> str:  # pragma: no cover - for debugging only
+        return f"<Project id={self.id!r} name={self.name!r}>"

--- a/app_flask/routes.py
+++ b/app_flask/routes.py
@@ -1,0 +1,24 @@
+"""HTTP route handlers for the hello-codex application."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from flask import Blueprint, jsonify
+
+from .models import Project
+
+bp = Blueprint("main", __name__)
+
+
+@bp.get("/")
+def index() -> tuple[dict[str, str], int]:
+    """Return a minimal JSON payload to verify the service is running."""
+    return jsonify({"message": "Hello from hello-codex"}), HTTPStatus.OK
+
+
+@bp.get("/projects")
+def list_projects() -> tuple[dict[str, list[str]], int]:
+    """List the names of registered projects."""
+    project_names = [project.name for project in Project.query.order_by(Project.name)]
+    return jsonify({"projects": project_names}), HTTPStatus.OK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Test fixtures for the hello-codex Flask application."""
+
+from __future__ import annotations
+
+import pytest
+
+from app_flask import create_app
+from app_flask.extensions import db
+
+
+@pytest.fixture
+def app():
+    """Create a Flask app instance for testing."""
+    application = create_app()
+
+    with application.app_context():
+        db.drop_all()
+        db.create_all()
+
+    yield application
+
+    with application.app_context():
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    """Return a test client bound to the app fixture."""
+    return app.test_client()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,26 @@
+"""Integration tests for the HTTP routes."""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+from app_flask.extensions import db
+from app_flask.models import Project
+
+
+def test_index_returns_greeting(client) -> None:
+    response = client.get("/")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"message": "Hello from hello-codex"}
+
+
+def test_projects_endpoint_lists_seeded_projects(app, client) -> None:
+    with app.app_context():
+        db.session.add(Project(name="Sample"))
+        db.session.commit()
+
+    response = client.get("/projects")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.get_json() == {"projects": ["Sample"]}


### PR DESCRIPTION
## Summary
- set up a Flask application factory with SQLAlchemy configured for a local SQLite database
- add a minimal Project model, JSON routes, and CLI helpers to initialise the schema
- document the bootstrap workflow and include pytest coverage for the new endpoints

## Testing
- pytest

## How to run locally
1. `python -m venv .venv && source .venv/bin/activate`
2. `pip install -U pip && pip install -e .[dev]`
3. `flask --app app_flask run --debug`


------
https://chatgpt.com/codex/tasks/task_e_68df91b82ebc8322965e62cbdd38a0ae